### PR TITLE
fix avro mapping of VI Event

### DIFF
--- a/src/src/main/avro/df_vi_submitted/vievent.avsc
+++ b/src/src/main/avro/df_vi_submitted/vievent.avsc
@@ -170,7 +170,7 @@
             {
               "name": "impoundLotOperator",
               "doc": "",
-              "type": "string"
+              "type": ["null","string"]
             },
             {
               "name": "dateOfImpound",


### PR DESCRIPTION
The Impound Lot Operator needs to accept null also for the VI event. This was identified after analysis of error occurred with the VI form 229439860.